### PR TITLE
Add fault-flag binary sensors (low battery, EOL, sensor faults)

### DIFF
--- a/custom_components/kidde_homesafe/binary_sensor.py
+++ b/custom_components/kidde_homesafe/binary_sensor.py
@@ -89,6 +89,62 @@ _BINARY_SENSOR_DESCRIPTIONS = (
         name="Reset Flag",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    BinarySensorEntityDescription(
+        key="flt_lwbat_mb",
+        icon="mdi:battery-alert",
+        name="Main Board Low Battery Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorEntityDescription(
+        key="flt_lwbat_wb",
+        icon="mdi:battery-alert",
+        name="Wireless Board Low Battery Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorEntityDescription(
+        key="flt_fat_lwbat",
+        icon="mdi:battery-alert",
+        name="Fatal Low Battery Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorEntityDescription(
+        key="flt_fat_eol",
+        icon="mdi:calendar-alert",
+        name="Fatal End of Life Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorEntityDescription(
+        key="flt_eol",
+        icon="mdi:calendar-alert",
+        name="End of Life Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorEntityDescription(
+        key="flt_pho",
+        icon="mdi:alert-circle",
+        name="Photoelectric Sensor Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorEntityDescription(
+        key="flt_co",
+        icon="mdi:alert-circle",
+        name="CO Sensor Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorEntityDescription(
+        key="flt_i2c",
+        icon="mdi:alert-circle",
+        name="I2C Bus Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
 )
 
 _INVERSE_BINARY_SENSOR_DESCRIPTIONS = (


### PR DESCRIPTION
## Summary

Adds 8 additional `BinarySensorEntityDescription` entries to `binary_sensor.py` for fault flags that Kidde's cloud API already returns per-device but that aren't currently mapped to any HA entity:

- `flt_lwbat_mb` — Main Board Low Battery Fault
- `flt_lwbat_wb` — Wireless Board Low Battery Fault
- `flt_fat_lwbat` — Fatal Low Battery Fault
- `flt_fat_eol` — Fatal End of Life Fault
- `flt_eol` — End of Life Fault
- `flt_pho` — Photoelectric Sensor Fault
- `flt_co` — CO Sensor Fault
- `flt_i2c` — I2C Bus Fault

All added as `EntityCategory.DIAGNOSTIC` with `BinarySensorDeviceClass.PROBLEM`, following the same pattern as the existing entries (e.g. `reset_flag`, `too_much_smoke`). No changes to `async_setup_entry` — the existing `if entity_description.key in device_data` guard already handles devices that don't report these fields.

## Motivation

Currently the integration only exposes a summarized `battery_state` ("Good"/not-Good) for battery health. These finer-grained fault flags are present in the raw API response (confirmed by pulling a live device payload directly) but aren't surfaced anywhere — not in this integration, and not in the Kidde app either. Exposing them lets users build earlier-warning automations (e.g. push notification the moment any fault flag changes) instead of relying solely on the coarse battery summary.

## Test plan
- [x] Deployed to a live Kidde DETECT-series smoke+CO alarm (`mb_model 48`) via manual `custom_components` install, confirmed all 8 new entities register correctly with expected default (`off`/normal) state and no errors in HA logs
- [x] Verified no regression to existing entities/behavior